### PR TITLE
fix: make files be builded at correct folder dist to get types correctly

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,9 @@ export default defineConfig({
       name,
     },
     rollupOptions: {
+      output: {
+        dir: 'dist',
+      },
       plugins: [
         peerDepsExternal(),
         typescript({


### PR DESCRIPTION
The types are not working as expected. At `package.json` the types are referencing at path `./dist/types/index.d.ts`, but at build the types are at path `./dist/dist/types/index.d.ts`.

So I specify the correct folder at `vite.config.ts` and now the types in build are in `./dist/types/index.d.ts`. Hope it works! :)

Any adjustments or improvement let me know. Thanks.