### PR TITLE
i18n: add italian translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Per default the locale is set to english `en`.
 
 Per default the word per minute is set to `300`.
 
-At the moment there is only 12 supported locales: `en`, `fr`, `es`, `pt-br`, `cn`, `ja`, `de`, `tr`, `ro`, `bn`, `sk` and `cs`.
+At the moment there are only 13 supported locales: `en`, `fr`, `es`, `pt-br`, `cn`, `ja`, `de`, `tr`, `ro`, `bn`, `sk`, `cs`, 'it'.
 
 ### Usage
 

--- a/lib/i18n/it.ts
+++ b/lib/i18n/it.ts
@@ -1,0 +1,6 @@
+import type { I18n } from './i18n'
+
+export const it: I18n = {
+  less: `meno di un minuto di lettura`,
+  default: 'min di lettura',
+}

--- a/lib/i18n/supportedLanguages.ts
+++ b/lib/i18n/supportedLanguages.ts
@@ -14,6 +14,7 @@ export const supportedLanguages = [
   'bn',
   'sk',
   'cs',
+  'it',
 ] as const
 
 /**

--- a/lib/i18n/translation.ts
+++ b/lib/i18n/translation.ts
@@ -12,6 +12,7 @@ import { ro } from './ro'
 import { bn } from './bn'
 import { sk } from './sk'
 import { cs } from './cs'
+import { it } from './it'
 
 export const translations: Record<SupportedLanguages, I18n> = {
   en,
@@ -26,4 +27,5 @@ export const translations: Record<SupportedLanguages, I18n> = {
   bn,
   sk,
   cs,
+  it,
 }


### PR DESCRIPTION
I added i18n for italian language.

It should be everything ok, but please check if it is working as intended