### PR TITLE
i18n: add russian, vietnamese, italian and indonesian languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Per default the locale is set to english `en`.
 
 Per default the word per minute is set to `300`.
 
-At the moment there is only 12 supported locales: `en`, `fr`, `es`, `pt-br`, `cn`, `ja`, `de`, `tr`, `ro`, `bn`, `sk` and `cs`.
+At the moment there is only 12 supported locales: `en`, `fr`, `es`, `pt-br`, `cn`, `ja`, `de`, `tr`, `ro`, `bn`, `sk`, `ru`, `vi`, `it`, `id` and `cs`.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Per default the locale is set to english `en`.
 
 Per default the word per minute is set to `300`.
 
-At the moment there is only 12 supported locales: `en`, `fr`, `es`, `pt-br`, `cn`, `ja`, `de`, `tr`, `ro`, `bn`, `sk`, `ru`, `vi`, `it`, `id` and `cs`.
+At the moment it supports these locales: `en`, `fr`, `es`, `pt-br`, `cn`, `ja`, `de`, `tr`, `ro`, `bn`, `sk`, `ru`, `vi`, `it`, `id` and `cs`.
 
 ### Usage
 

--- a/__tests__/reading-time-estimation.spec.ts
+++ b/__tests__/reading-time-estimation.spec.ts
@@ -29,6 +29,14 @@ const slovakText = `Reading Time Estimator bol vytvorený s cieľom poskytnúť 
 
 const czechText = `Reading Time Estimator byl vytvořen s cílem poskytnout odhad, jak dlouhou dobu je zapotřebí k přečtení článku nebo blogu tak, jak je to implementováno na stránce medium.`
 
+const russianText = `Reading Time Estimator был создан, чтобы предоставить оценку времени, необходимого для прочтения статьи или блога, так, как это реализовано на сайте medium.`;
+
+const vietnameseText = `Reading Time Estimator được tạo ra nhằm cung cấp ước tính về thời gian cần thiết để đọc một bài viết hoặc blog, giống như cách nó được triển khai trên trang medium.`;
+
+const italianText = `Reading Time Estimator è stato creato per fornire una stima di quanto tempo sia necessario per leggere un articolo o un blog, così come viene implementato sul sito medium.`;
+
+const indonesianText = `Reading Time Estimator dibuat untuk memberikan perkiraan waktu yang dibutuhkan untuk membaca artikel atau blog, sebagaimana diimplementasikan di situs medium.`;
+
 interface TestSetup {
   readonly language: SupportedLanguages | undefined
   readonly words: string | undefined
@@ -182,6 +190,46 @@ describe('readingTime', () => {
         minutes: 3,
         words: 27,
         text: `3 ${translations['cs'].default}`,
+      },
+    },
+    {
+      language: 'ru',
+      words: russianText,
+      wordsPerMinute: 10,
+      expectedResult: {
+        minutes: 1,
+        words: 8,
+        text: `${translations['ru'].less}`,
+      },
+    },
+    {
+      language: 'vi',
+      words: vietnameseText,
+      wordsPerMinute: 10,
+      expectedResult: {
+        minutes: 5,
+        words: 48,
+        text: `5 ${translations['vi'].default}`,
+      },
+    },
+    {
+      language: 'it',
+      words: italianText,
+      wordsPerMinute: 10,
+      expectedResult: {
+        minutes: 3,
+        words: 29,
+        text: `3 ${translations['it'].default}`,
+      },
+    },
+    {
+      language: 'id',
+      words: indonesianText,
+      wordsPerMinute: 10,
+      expectedResult: {
+        minutes: 2,
+        words: 20,
+        text: `2 ${translations['id'].default}`,
       },
     },
   ])(

--- a/lib/i18n/id.ts
+++ b/lib/i18n/id.ts
@@ -1,0 +1,6 @@
+import type { I18n } from './i18n'
+
+export const id: I18n = {
+  less: 'kurang dari satu menit baca',
+  default: 'menit baca',
+}

--- a/lib/i18n/it.ts
+++ b/lib/i18n/it.ts
@@ -1,0 +1,6 @@
+import type { I18n } from './i18n'
+
+export const it: I18n = {
+  less: 'meno di un minuto di lettura',
+  default: 'min di lettura',
+}

--- a/lib/i18n/ru.ts
+++ b/lib/i18n/ru.ts
@@ -1,0 +1,6 @@
+import type { I18n } from './i18n'
+
+export const ru: I18n = {
+  less: 'менее минуты чтения',
+  default: 'мин чтения',
+}

--- a/lib/i18n/supportedLanguages.ts
+++ b/lib/i18n/supportedLanguages.ts
@@ -14,6 +14,7 @@ export const supportedLanguages = [
   'bn',
   'sk',
   'cs',
+  'ru',
 ] as const
 
 /**

--- a/lib/i18n/supportedLanguages.ts
+++ b/lib/i18n/supportedLanguages.ts
@@ -15,6 +15,7 @@ export const supportedLanguages = [
   'sk',
   'cs',
   'ru',
+  'vi',
 ] as const
 
 /**

--- a/lib/i18n/supportedLanguages.ts
+++ b/lib/i18n/supportedLanguages.ts
@@ -16,6 +16,7 @@ export const supportedLanguages = [
   'cs',
   'ru',
   'vi',
+  'it',
 ] as const
 
 /**

--- a/lib/i18n/supportedLanguages.ts
+++ b/lib/i18n/supportedLanguages.ts
@@ -17,6 +17,7 @@ export const supportedLanguages = [
   'ru',
   'vi',
   'it',
+  'id',
 ] as const
 
 /**

--- a/lib/i18n/translation.ts
+++ b/lib/i18n/translation.ts
@@ -14,6 +14,7 @@ import { sk } from './sk'
 import { cs } from './cs'
 import { ru } from './ru'
 import { vi } from './vi'
+import { it } from './it'
 
 export const translations: Record<SupportedLanguages, I18n> = {
   en,
@@ -30,4 +31,5 @@ export const translations: Record<SupportedLanguages, I18n> = {
   cs,
   ru,
   vi,
+  it,
 }

--- a/lib/i18n/translation.ts
+++ b/lib/i18n/translation.ts
@@ -15,6 +15,7 @@ import { cs } from './cs'
 import { ru } from './ru'
 import { vi } from './vi'
 import { it } from './it'
+import { id } from './id'
 
 export const translations: Record<SupportedLanguages, I18n> = {
   en,
@@ -32,4 +33,5 @@ export const translations: Record<SupportedLanguages, I18n> = {
   ru,
   vi,
   it,
+  id,
 }

--- a/lib/i18n/translation.ts
+++ b/lib/i18n/translation.ts
@@ -13,6 +13,7 @@ import { bn } from './bn'
 import { sk } from './sk'
 import { cs } from './cs'
 import { ru } from './ru'
+import { vi } from './vi'
 
 export const translations: Record<SupportedLanguages, I18n> = {
   en,
@@ -28,4 +29,5 @@ export const translations: Record<SupportedLanguages, I18n> = {
   sk,
   cs,
   ru,
+  vi,
 }

--- a/lib/i18n/translation.ts
+++ b/lib/i18n/translation.ts
@@ -12,6 +12,7 @@ import { ro } from './ro'
 import { bn } from './bn'
 import { sk } from './sk'
 import { cs } from './cs'
+import { ru } from './ru'
 
 export const translations: Record<SupportedLanguages, I18n> = {
   en,
@@ -26,4 +27,5 @@ export const translations: Record<SupportedLanguages, I18n> = {
   bn,
   sk,
   cs,
+  ru,
 }

--- a/lib/i18n/vi.ts
+++ b/lib/i18n/vi.ts
@@ -1,0 +1,6 @@
+import type { I18n } from './i18n'
+
+export const vi: I18n = {
+  less: 'chưa đầy một phút đọc',
+  default: 'phút đọc',
+}


### PR DESCRIPTION
Added support for `russian`, `vietnamese`, `italian` and `indonesian` language for the package using ChatGPT to translate some of it. Let me know if there is something to improve here, thanks 🙏 