### PR TITLE
feat: zh-tw support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Per default the locale is set to english `en`.
 
 Per default the word per minute is set to `300`.
 
-At the moment there is only 12 supported locales: `en`, `fr`, `es`, `pt-br`, `zh-cn`, `zh-tw`, `ja`, `de`, `tr`, `ro`, `bn`, `sk` and `cs`.
+At the moment it supports these locales: `en`, `fr`, `es`, `pt-br`, `zh-cn`, `zh-tw`, `ja`, `de`, `tr`, `ro`, `bn`, `sk` and `cs`.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Per default the locale is set to english `en`.
 
 Per default the word per minute is set to `300`.
 
-At the moment there is only 12 supported locales: `en`, `fr`, `es`, `pt-br`, `cn`, `ja`, `de`, `tr`, `ro`, `bn`, `sk` and `cs`.
+At the moment there is only 12 supported locales: `en`, `fr`, `es`, `pt-br`, `zh-cn`, `zh-tw`, `ja`, `de`, `tr`, `ro`, `bn`, `sk` and `cs`.
 
 ### Usage
 

--- a/__tests__/reading-time-estimation.spec.ts
+++ b/__tests__/reading-time-estimation.spec.ts
@@ -4,7 +4,9 @@ import type { SupportedLanguages } from '../lib/i18n'
 
 const englishText = `I never took the time to properly build my website even though I am a Frontend Developer. I started to look at some technologies in 2018 and 2019, I found some amazing projects (nuxt, vuepress, etc...) but I never did finish my website.`
 
-const chineseText = `中文 多来几个字`
+const simplifiedChineseText = `中文 多来几个字`
+
+const traditionalChineseText = `繁體中文，海上生明月，天涯共此時。`
 
 const frenchText = `Reading Time Estimator a été créé pour fournir une estimation de la durée de lecture d'un article ou d'un blog comme vu sur medium`
 
@@ -75,13 +77,23 @@ describe('readingTime', () => {
       expectedResult: { minutes: 0, words: 0, text: translations['en'].less },
     },
     {
-      language: 'cn',
-      words: chineseText,
+      language: 'zh-cn',
+      words: simplifiedChineseText,
       wordsPerMinute: 2,
       expectedResult: {
         minutes: 4,
         words: 7,
-        text: `4 ${translations['cn'].default}`,
+        text: `4 ${translations['zh-cn'].default}`,
+      },
+    },
+    {
+      language: 'zh-tw',
+      words: traditionalChineseText,
+      wordsPerMinute: 2,
+      expectedResult: {
+        minutes: 7,
+        words: 14,
+        text: `7 ${translations['zh-tw'].default}`,
       },
     },
     {

--- a/lib/i18n/supportedLanguages.ts
+++ b/lib/i18n/supportedLanguages.ts
@@ -5,7 +5,9 @@ export const supportedLanguages = [
   'en',
   'fr',
   'es',
-  'cn',
+  'cn', // keeping for compatibility
+  'zh-cn',
+  'zh-tw',
   'ja',
   'de',
   'pt-br',

--- a/lib/i18n/translation.ts
+++ b/lib/i18n/translation.ts
@@ -1,7 +1,7 @@
 import { en } from './en'
 import { fr } from './fr'
 import { es } from './es'
-import { cn } from './cn'
+import { zhCn } from './zh-cn'
 import { ja } from './ja'
 import { de } from './de'
 import type { I18n } from './i18n'
@@ -12,12 +12,15 @@ import { ro } from './ro'
 import { bn } from './bn'
 import { sk } from './sk'
 import { cs } from './cs'
+import { zhTw } from './zh-tw'
 
 export const translations: Record<SupportedLanguages, I18n> = {
   en,
   fr,
   es,
-  cn,
+  'zh-cn': zhCn,
+  'zh-tw': zhTw,
+  cn: zhCn,
   ja,
   de,
   'pt-br': ptBr,

--- a/lib/i18n/zh-cn.ts
+++ b/lib/i18n/zh-cn.ts
@@ -1,6 +1,6 @@
 import type { I18n } from './i18n'
 
-export const cn: I18n = {
+export const zhCn: I18n = {
   less: '小于一分钟',
   default: '分钟',
 }

--- a/lib/i18n/zh-tw.ts
+++ b/lib/i18n/zh-tw.ts
@@ -1,0 +1,6 @@
+import type { I18n } from './i18n'
+
+export const zhTw: I18n = {
+  less: '少於一分鐘',
+  default: '分鐘',
+}


### PR DESCRIPTION
Added support for `zh-tw`. And the original `cn` locale has been renamed to `zh-cn`. For compatibility, `cn` is retained as an alias for `zh-cn`. If you have any questions, please feel free to let me know!